### PR TITLE
Fix #38 rely on dropboxRefreshToken +refacto

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,13 +1,27 @@
 [ < Back](../README.md)
 
-# HowTo Contribute
+# Github users HowTos
 
-Please create an [issue](https://github.com/boly38/drobadi/issues) describing your goal / qustion / bug description..
+## HowTo contribute
+
+Please create an [issue](https://github.com/boly38/drobadi/issues) describing your goal / idea / question / bug description...
 
 If you want to push some code :
-- fork and prepare a feature-git-branch, then create a [pull request](https://github.com/boly38/drobadi/pulls) that link your issue.
+- following next `HowTo push some code` guide,
+- create a [pull request](https://github.com/boly38/drobadi/pulls) that link your issue using `#<issue_id>`.
 
-# Maintainer HowTos
+## HowTo push some code
+
+Follow this steps:
+- fork the repository using Github portal.
+- Clone your fork locally
+- Prepare a feature branch `checkout -b my_idea`
+- add some code
+- double check green Unit Tests : `DROBADI_TEST_VERBOSE=true npm test`
+
+
+# Maintainers HowTos
+
 ## HowTo release using Gren
 
 ```bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,9 @@ jobs:
       env:
         DROBADI_TEST_VERBOSE: true
         DROBADI_ARCHIVER_VERBOSE: true
-        DROBADI_TEST_DROPBOX_TOKEN: ${{ secrets.DROBADI_TEST_DROPBOX_TOKEN }}
+        DROBADI_TEST_APP_KEY : ${{ secrets.DROBADI_TEST_APP_KEY  }}
+        DROBADI_TEST_APP_SECRET : ${{ secrets.DROBADI_TEST_APP_SECRET  }}
+        DROBADI_TEST_REFRESH_TOKEN : ${{ secrets.DROBADI_TEST_REFRESH_TOKEN  }}
       run: npm run ci-test
 
     - name: Report coverage

--- a/README.md
+++ b/README.md
@@ -16,12 +16,16 @@ A NodeJS tool to
 **install drobadi**
 
 ```
-npm install drobadi --global
+npm install drobadi@latest --global
 ```
 
 **set your preferences**
 
-A dropbox access token is required.
+A dropbox application (`dropboxAppKey`,`dropboxAppSecret`), and long-lived refresh-token (`dropboxRefreshToken`) are required.
+
+NB: in order to understand how-to get a `refresh-token, cf [dropbox-refresh-token](https://github.com/boly38/dropbox-refresh-token)
+
+The old-long-lived access-token (`dropboxToken`) are always supported but this method is deprecated and will be removed in futur release.
 
 ```
 drobadi setup
@@ -85,11 +89,17 @@ drobadi download biolo.zip /tmp/ddd.zip
 
 ## DOptions
 Drobadi options are
-- `dropboxToken` (or `DBD_DROPBOX_TOKEN` env. Default: `null`. **Mandatory**) : dropbox access token value,
-- `path` (or `DBD_PATH` env. Default: `backup`) : dropbox backup directory.
-- `force` (or `DBD_FORCE` env. Default: `false`) : override target backup.
+- `dropboxAppKey` (or `DBD_DROPBOX_APP_KEY` env. Default: `null`. **Required**) : [dropbox application](https://www.dropbox.com/developers/apps/) key.
+- `dropboxAppSecret` (or `DBD_DROPBOX_APP_SECRET` env. Default: `null`. **Required**) : dropbox application secret.
+- `dropboxRefreshToken` (or `DBD_DROPBOX_REFRESH_TOKEN`. Default: `null`.  env. **Required**) : dropbox application [refresh-token](https://github.com/boly38/dropbox-refresh-token).
+- `path` (or `DBD_PATH` env. Default: `backup`) : dropbox target directory that receive backup files.
+- `force` (or `DBD_FORCE` env. Default: `false`) : override target backup file.
 
-Note that `drobadi setup` creates a `~/.drobadi` config file.
+Deprecated option:
+- `dropboxToken` (or `DBD_DROPBOX_TOKEN` env. Default: `null`. **DEPRECATED**) : dropbox access-token value,
+- `dropboxTokenDisableWarning` (or `DBD_DROPBOX_TOKEN_DISABLE_WARNING` env. Default: `false`.*) : change-it to disable warning log.
+
+Note that `drobadi setup` help you to create a `~/.drobadi` config file.
 
 DOptions precedence: options object, or env value or config file or default value.
 

--- a/bin/drobadi.js
+++ b/bin/drobadi.js
@@ -1,7 +1,16 @@
 #!/usr/bin/env node
 
 import DCommand from '../lib/DCommand.js';
+import {isSet} from "../lib/utils.js";
 // take first command line argument
 const action = process.argv.slice(2)[0];
 const args = process.argv.slice(3);
-(new DCommand()).doAction(action, args);
+(new DCommand()).doAction(action, args)
+    .then(result => {
+        if (isSet(result)) {
+            console.log(result);
+        }
+    })
+    .catch(error => {
+        console.warn(error.message)
+    });

--- a/drobadi.js
+++ b/drobadi.js
@@ -1,5 +1,14 @@
 import DCommand from './lib/DCommand.js';
+import {isSet} from "./lib/utils.js";
 // take first command line argument
 const action = process.argv.slice(2)[0];
 const args = process.argv.slice(3);
-(new DCommand()).doAction(action, args);
+(new DCommand()).doAction(action, args)
+    .then(result => {
+        if (isSet(result)) {
+            console.log(result);
+        }
+    })
+    .catch(error => {
+        console.warn(error.message)
+    });

--- a/env/initEnv.template.sh
+++ b/env/initEnv.template.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
 # test dropbox feature
-# https://www.dropbox.com/developers/apps/ : create an app and a token from oauth2 section
-# export DROBADI_TEST_DROPBOX_TOKEN=
 # DROBADI_TEST_VERBOSE=true
 # DROBADI_ARCHIVER_VERBOSE=true
+
+# TIP: get key,secret from dropbox developers app dev portal : https://www.dropbox.com/developers/apps/
+# DROBADI_TEST_APP_KEY=
+# DROBADI_TEST_APP_SECRET=
+# TIP: long-lived offline refresh-token. cf. https://github.com/boly38/dropbox-refresh-token
+# DROBADI_TEST_REFRESH_TOKEN=
+
+
+## DEPRECATED SECTION
+# DROBADI_TEST_DROPBOX_TOKEN - old-long-lived access-token - no more available from dropbox developers portal
+# export DROBADI_TEST_DROPBOX_TOKEN=
+## DEPRECATED SECTION end

--- a/lib/DCommand.js
+++ b/lib/DCommand.js
@@ -2,13 +2,14 @@ import path from 'path';
 import {logError, logInfo, logSuccess} from './utils.js';
 import DOptions from './DOptions.js';
 import DropboxBackupDirectory from "./DropboxBackupDirectory.js";
+import {dOptionLocalConfigFileSetup} from "./DOptionLocalConfigFile.js";
 
 const commands = [
     'setup',
     'backup <directory> [<targetName>:myBackup.zip]',
     'forceBackup <directory> [<targetName>:myBackup.zip]',
     'list',
-    'download <myBackup.zip> [<localFile]',
+    'download <myBackup.zip> [<localFile>]',
     'unlink'
 ];
 const withArgsCommands = ['backup', 'download', 'get', 'retrieve', 'forceBackup'];
@@ -51,38 +52,43 @@ export default class DCommand {
     }
 
     list() {
-        this.dbd.list(new DOptions())
-            .catch(this.logErrorReject)
-            .then(listResult => {
-                if (!Array.isArray(listResult) || !listResult.length) {
-                    logInfo("aucun backup");
-                    return Promise.resolve();
-                } else {
-                    logInfo("dropbox backups :\n");
-                    logInfo(listResult.map(r => `\t${r}\n`).join(''));
-                }
-                return Promise.resolve();
-            });
+        return new Promise((resolve, reject) => {
+            this.dbd.list(new DOptions())
+                .then(listResult => {
+                    if (!Array.isArray(listResult) || !listResult.length) {
+                        logInfo("aucun backup");
+                    } else {
+                        logInfo("dropbox backups :\n");
+                        logInfo(listResult.map(r => `\t${r}\n`).join(''));
+                    }
+                    resolve();
+                })
+                .catch(reject);
+        });
     }
 
     backup(force, toBackup, zipDestinationName = 'myBackup.zip') {
-        let dOptions = new DOptions({force});
-        let itemToBackup = process.cwd() + '/' + toBackup;
-        this.dbd.backup(dOptions, itemToBackup, zipDestinationName)
-            .catch(this.logErrorReject)
-            .then(backupResult => {
-                logSuccess(`Backup done ${backupResult.uploadResult.dropboxFileSize}o - path:${backupResult.uploadResult.dropboxFile}`);
-                return Promise.resolve();
-            });
+        return new Promise((resolve, reject) => {
+            let dOptions = new DOptions({force});
+            let itemToBackup = process.cwd() + '/' + toBackup;
+            this.dbd.backup(dOptions, itemToBackup, zipDestinationName)
+                .then(backupResult => {
+                    logSuccess(`Backup done ${backupResult.uploadResult.dropboxFileSize}o - path:${backupResult.uploadResult.dropboxFile}`);
+                    return Promise.resolve();
+                })
+                .catch(reject);
+        });
     }
 
     retrieve(dbxBackupFile, localFile = null) {
-        this.dbd.download(new DOptions(), dbxBackupFile, localFile)
-            .catch(this.logErrorReject)
-            .then(downloadResult => {
-                logSuccess(downloadResult.downloadResult.message)
-                return Promise.resolve();
-            });
+        return new Promise((resolve, reject) => {
+            this.dbd.download(new DOptions(), dbxBackupFile, localFile)
+                .then(downloadResult => {
+                    logSuccess(downloadResult.downloadResult.message)
+                    resolve();
+                })
+                .catch(reject);
+        });
     }
 
     doAction(action = null, args = null) {
@@ -93,11 +99,11 @@ export default class DCommand {
             }
 
             if (['list', 'ls', 'dir'].includes(action)) {
-                return cmd.list();
+                return cmd.list().then(resolve).catch(reject);
             }
 
             if (['setup', 'install', 'config'].includes(action)) {
-                DOptions.setup().catch(reject).then(() => {
+                dOptionLocalConfigFileSetup().catch(reject).then(() => {
                     logInfo("TIP: use 'unlink' action to remove default setup config file")
                     resolve();
                 });
@@ -106,9 +112,9 @@ export default class DCommand {
                 DOptions.unlink();
                 resolve();
             } else if (['backup', 'forceBackup'].includes(action)) {
-                return cmd.backup(('forceBackup' === action), args[0], args[1]);
+                return cmd.backup(('forceBackup' === action), args[0], args[1]).then(resolve).catch(reject);
             } else if (['download', 'get', 'retrieve'].includes(action)) {
-                return this.retrieve(args[0], args[1]);
+                return this.retrieve(args[0], args[1]).then(resolve).catch(reject);
             } else {
                 // Note for Windows users: in case of path issue, set MSYS_NO_PATHCONV=1 may help.
                 return this.printUsage();

--- a/lib/DDropbox.js
+++ b/lib/DDropbox.js
@@ -1,120 +1,169 @@
 import fs from 'fs';
 import path from "path";
 import {Dropbox} from 'dropbox'; // https://www.npmjs.com/package/dropbox
-import {isSet, mkdirSync} from './utils.js';
+import {isSet, mkdirSync, unlinkIfExists} from './utils.js';
 
-const MUST_LOG_DEBUG = process.env.DROBADI_DROPBOX_DEBUG || false;
-const MUST_LOG_INFO = process.env.DROBADI_DROPBOX_VERBOSE || false;
+import {refreshAccessToken, isAccessTokenValid} from "dropbox-refresh-token";
+
+const MUST_LOG_DEBUG = process.env.DROBADI_DROPBOX_DEBUG === "true" || false;
+const MUST_LOG_INFO = process.env.DROBADI_DROPBOX_VERBOSE  === "true"|| false;
+
 const getDropbox = options => {
-    const accessToken = options.dropboxToken;
-    if (!isSet(accessToken)) {
-        throw new Error("Dropbox token is not set");
-    }
-    return new Dropbox({accessToken});
-};
+    return new Promise((resolve, reject) => {
+        const {
+            dropboxToken: accessToken,// keep legacy token
+            dropboxRefreshToken, dropboxAppKey, dropboxAppSecret, // current way to proceed
+            freshAccessToken // accessToken: set when already retrieved from current session
+        } = options;
+        if (MUST_LOG_DEBUG && isSet(freshAccessToken)) {
+            console.log("we will reuse access-token")
+        }
+        const currentAccessToken = isSet(freshAccessToken) ? freshAccessToken : accessToken;
+        isAccessTokenValid(currentAccessToken).then(result => {
+            const {isValid, info} = result;
+            if (isValid) {
+                if (MUST_LOG_DEBUG) {
+                    console.log(`use valid access-token from ${info.email}`)
+                }
+                resolve(new Dropbox({"accessToken": currentAccessToken}));
+            }
+        }).catch(rejectResult => {
+            const {isValid, error} = rejectResult;
+            MUST_LOG_DEBUG && console.log(`isValid:${isValid} error:${error} - so dropboxRefreshAccessToken`);
+            if (!isSet(dropboxRefreshToken) || !isSet(dropboxAppKey) || !isSet(dropboxAppSecret)) {
+                reject(new Error("to refresh a dropbox access token, following options are required: dropboxRefreshToken, dropboxAppKey, dropboxAppSecret"));
+                return;
+            }
+            refreshAccessToken(dropboxRefreshToken, dropboxAppKey, dropboxAppSecret)
+                .then(freshAccessToken => {
+                    options.freshAccessToken = freshAccessToken;
+                    resolve(new Dropbox({"accessToken": freshAccessToken}))
+                })
+                .catch(err => reject(err))
+        });
+    })
+}
 
 export default class DDropbox {
     // https://github.com/dropbox/dropbox-sdk-js/blob/main/examples/javascript/node/basic.js
     listFromDropbox(options) {
-        const dbx = getDropbox(options);
-        const path = options.getDropboxPath();
-        MUST_LOG_INFO && console.log(`list ${path}:`);
         return new Promise((resolve, reject) => {
-            // DEBUG // console.log(`Dropbox filesListFolder ${path}:`);
-            dbx.filesListFolder({path})
-                .then(response => {
-                    MUST_LOG_DEBUG && console.log(response.result);
-                    MUST_LOG_DEBUG && console.log(response.headers);
-                    const fileNames = response.result.entries
-                        .filter(e => e[".tag"] === "file")
-                        .map(e => e.path_lower);
-                    MUST_LOG_DEBUG && console.log('response', fileNames)
-                    resolve(fileNames);
-                })
-                .catch(filesListError => {
-                    if (filesListError.code === 409) {
-                        reject(new Error(`Dropbox target ${path} dont exist`));
-                        return;
-                    }
-                    reject(filesListError);
-                });
+            getDropbox(options).then(dbx => {
+                const path = options.getDropboxPath();
+                MUST_LOG_INFO && console.log(`list ${path}:`);
+                // DEBUG // console.log(`Dropbox filesListFolder ${path}:`);
+                dbx.filesListFolder({path})
+                    .then(response => {
+                        MUST_LOG_DEBUG && console.log(response.result);
+                        MUST_LOG_DEBUG && console.log(response.headers);
+                        const fileNames = response.result.entries
+                            .filter(e => e[".tag"] === "file")
+                            // remove prefix
+                            .map(e => e.path_lower)
+                            .map(e => { return e.startsWith(path) ? e.substring(path.length+1) : e; })
+                        ;
+                        MUST_LOG_DEBUG && console.log('response', fileNames)
+                        resolve(fileNames);
+                    })
+                    .catch(filesListError => {
+                        MUST_LOG_DEBUG && console.log('filesListError', filesListError)
+                        const {status, error} = filesListError;
+                        if (status === 409) {
+                            reject(new Error(`Dropbox target '${path}' dont exist`));
+                            return;
+                        }
+                        const errorMessage = `list ${path}: [status:${status}] ${error?.error_summary}`;
+                        reject(new Error(errorMessage));
+                    });
+            }).catch(err => reject(err));
+
         });
     }
 
     // https://github.com/dropbox/dropbox-sdk-js/blob/main/examples/javascript/node/upload.js
     uploadOnDropbox(options, backupFile, dbxFilename) {
-        const dbxPath = options.getDropboxPath();
-        const dbxFullFilename = dbxPath + "/" + dbxFilename;
-        const mode = (options.force === true) ? 'overwrite' : 'add';// {('add'|'overwrite'|'update')} // https://github.com/dropbox/dropbox-sdk-js/blob/main/lib/types.js#L2539C23-L2539C32
-        MUST_LOG_DEBUG && console.log(`uploadOnDropbox file:${backupFile} to ${dbxFullFilename} mode:${mode}`);
         return new Promise((resolve, reject) => {
+            const dbxPath = options.getDropboxPath();
+            const dbxFullFilename = dbxPath + "/" + dbxFilename;
+            const mode = (options.force === true) ? 'overwrite' : 'add';// {('add'|'overwrite'|'update')} // https://github.com/dropbox/dropbox-sdk-js/blob/main/lib/types.js#L2539C23-L2539C32
+            MUST_LOG_DEBUG && console.log(`uploadOnDropbox file:${backupFile} to ${dbxFullFilename} mode:${mode}`);
             fs.readFile(backupFile, (readFileError, contents) => {
                 if (readFileError) {
                     return reject(readFileError);
                 }
-                const dbx = getDropbox(options);
-                let filesUploadArgs = {"path": dbxFullFilename, mode, contents};// https://github.com/dropbox/dropbox-sdk-js/blob/main/lib/types.js#L2274
-                dbx.filesUpload(filesUploadArgs)
-                    .then(response => {
-                        const result = response.result;
-                        resolve({
-                            "dropboxFile": result.path_display,
-                            "dropboxFileSize": result.size,
-                            "message": `backup uploaded on dropbox as ${dbxFullFilename}`
-                        });
-                    })
-                    .catch(uploadErr => {
-                        MUST_LOG_DEBUG && console.log("files/upload", JSON.stringify(uploadErr));
-                        if (uploadErr.code === 409) {
-                            reject(new Error(`Dropbox target ${dbxFullFilename} already exists`));
-                        }
-                        return reject(uploadErr);
-                    })
+                getDropbox(options).then(dbx => {
+                    let filesUploadArgs = {"path": dbxFullFilename, mode, contents};// https://github.com/dropbox/dropbox-sdk-js/blob/main/lib/types.js#L2274
+                    dbx.filesUpload(filesUploadArgs)
+                        .then(response => {
+                            const result = response.result;
+                            resolve({
+                                "dropboxFile": result.path_display,
+                                "dropboxFileSize": result.size,
+                                "message": `backup uploaded on dropbox as ${dbxFullFilename}`
+                            });
+                        })
+                        .catch(uploadErr => {
+                            MUST_LOG_DEBUG && console.log("files/upload", JSON.stringify(uploadErr));
+                            const {status, error} = uploadErr;
+                            if (status === 409) {
+                                reject(new Error(`Dropbox target ${dbxFullFilename} already exists`));
+                            }
+                            if (error) {
+                                const {error_summary} = error;
+                                const errorMessage = `upload ${dbxFullFilename}: [status:${status}] ${error_summary}`;
+                                reject(new Error(errorMessage));
+                            }
+                        })
+                }).catch(err => reject(err));
             });
         })
     }
 
     // https://github.com/dropbox/dropbox-sdk-js/blob/main/examples/javascript/node/download.js
     downloadFromDropbox(options, dbxFilename, localFile) {
-        if (!isSet(dbxFilename)) {
-            return Promise.reject(new Error(`please provide a target dropbox filename`));
-        }
-        if (!isSet(localFile)) {
-            return Promise.reject(new Error(`please provide a local filename`));
-        }
         return new Promise((resolve, reject) => {
+            if (!isSet(dbxFilename)) {
+                return reject(new Error(`please provide a target dropbox filename`));
+            }
+            if (!isSet(localFile)) {
+                return reject(new Error(`please provide a local filename`));
+            }
             MUST_LOG_DEBUG && console.log(`dbxFilename:${dbxFilename}, localFile:${localFile}`);
             const fileToDownload = this.prepareFileToUpload(dbxFilename, options);
             this.prepareLocalPath(localFile);
 
             MUST_LOG_DEBUG && console.log("files/download", fileToDownload);
-            const dbx = getDropbox(options);
-            dbx.filesDownload({"path": fileToDownload})
-                .then(reponse => {
-                    const responseResult = reponse.result;
-                    // DEBUG // console.log(reponse.result);
-                    fs.writeFileSync(localFile, responseResult.fileBinary);
-                    resolve({
-                        "dropboxFile": responseResult.path_display,
-                        "dropboxFileSize": responseResult.size,
-                        "message": `backup downloaded into ${localFile} (${responseResult.size}o)`,
-                        localFile
+            getDropbox(options).then(dbx => {
+                dbx.filesDownload({"path": fileToDownload})
+                    .then(response => {
+                        // DEBUG // console.log(response.result);
+                        const {path_display: dropboxFile, size: dropboxFileSize, fileBinary} = response.result;
+                        fs.writeFileSync(localFile, fileBinary);
+                        resolve({
+                            dropboxFile,
+                            dropboxFileSize,
+                            "message": `backup downloaded into ${localFile} (${dropboxFileSize}o)`,
+                            localFile
+                        });
+                    })
+                    .catch(uploadErr => {
+                        MUST_LOG_DEBUG && console.log("files/download", JSON.stringify(uploadErr));
+                        const {status, error} = uploadErr;
+                        if (error) {
+                            const {error_summary} = error;
+                            unlinkIfExists(localFile);// remove temp zip file
+                            if (status === 409 && fileToDownload.includes("/C:/")) {
+                                reject(new Error(`Dropbox is not able to download ${fileToDownload} : ${error_summary} `+
+                                `\n\t-TIP- the file path is strange, you may type only filename to download without directory`));
+                            } else if (status === 409) {
+                                reject(new Error(`Dropbox is not able to download ${fileToDownload} : ${error_summary}`));
+                            } else {
+                                const errorMessage = `download ${fileToDownload}: [status:${status}] ${error_summary}`;
+                                reject(new Error(errorMessage));
+                            }
+                        }
                     });
-                })
-                .catch(uploadErr => {
-                    MUST_LOG_DEBUG && console.log("files/download", JSON.stringify(uploadErr));
-                    if (uploadErr) {
-                        if (fs.existsSync(localFile)) {
-                          // remove temp zip file
-                          fs.unlinkSync(localFile);
-                        }
-                        if (uploadErr.code === 409) {
-                            reject(new Error(`Dropbox is not able to download ${fileToDownload} : ${uploadErr.error_summary})`));
-                        } else {
-                            reject(uploadErr);
-                        }
-                    }
-                });
+            }).catch(err => reject(err));
 
         });
     }

--- a/lib/DOptionLocalConfigFile.js
+++ b/lib/DOptionLocalConfigFile.js
@@ -1,0 +1,83 @@
+import {isSet} from "./utils.js";
+import fs from "fs";
+import DOptions, {DEFAULT_CONFIG_FILE, DEFAULT_CONFIG_FILE_FRIENDLY} from "./DOptions.js";
+import yesno from 'yesno';
+import inquirer from 'inquirer';
+
+const dropboxDeveloperSetupApplication = () => console.log(
+    "please follow this instructions to create a dropbox application:\n\n" +
+    "\t1) Open the following URL in your Browser, and log in using your account: https://www.dropbox.com/developers/apps (keep free default option with 2GB)\n" +
+    "\t2) Go to developer center : https://www.dropbox.com/developers/apps/\n and Click on `Create App`, then select `Scoped access`, a type of access (ex. folder) and name your app to create it.\n" +
+    "\t3) In the configuration, choose the app `Permissions` tab : you must check `files.content.write` and `files.content.read` and submit.\n" +
+    "\t4) In the configuration, choose the app `Settings` tab : you have here 'App key' and 'App secret'.\n"
+);
+
+const dropboxDeveloperApplicationRefreshToken = () => console.log(
+    "please obtains a dropbox offline long-lived refresh token for your application: you must follow HowTo from https://github.com/boly38/dropbox-refresh-token"
+);
+
+const setupOptionValueFromPrompt = (option, name, message) => {
+    return new Promise(resolve => {
+        const questions = [{type: 'input', name, message}];
+        inquirer.prompt(questions).then(answers => {
+            option[name] = answers[name];
+            resolve(option);
+        });
+    });
+}
+
+const setupOptionDropboxRefreshToken = option => {
+    dropboxDeveloperSetupApplication();
+    return new Promise(resolve => {
+        setupOptionValueFromPrompt(option, "dropboxAppKey", "Dropbox App key ").then(optionAppK => {
+            setupOptionValueFromPrompt(optionAppK, "dropboxAppSecret", "Dropbox App secret").then(optionAppKS => {
+                dropboxDeveloperApplicationRefreshToken();
+                setupOptionValueFromPrompt(optionAppKS, "dropboxRefreshToken", "Dropbox Refresh Token").then(optionAppKSRT => {
+                    resolve(optionAppKSRT);
+                });
+            });
+        });
+    })
+}
+
+const setupTargetConfigFile = (defaultConfigFile) => {
+    return new Promise(resolve => {
+        const questions = [{
+            type: 'input',
+            name: 'configLocation',
+            message: `Dropbox target config file (default is ${defaultConfigFile})`
+        }];
+        inquirer.prompt(questions).then(answers => {
+            resolve(answers.configLocation)
+        });
+    });
+}
+
+export const dOptionLocalConfigFileSetup = async () => {
+    let targetConfigFile = DEFAULT_CONFIG_FILE;
+    let currentOption = new DOptions();
+    if (!isSet(currentOption.dropboxToken)
+        || (await yesno({
+            question: 'Would you like to set dropbox application and refresh-token ? (y/n)',
+            defaultValue: null
+        }))) {
+        currentOption = await setupOptionDropboxRefreshToken(currentOption);
+    }
+    if (await yesno({
+        question: `Would you like to update default dropbox directory(default: ${currentOption.path}) ? (y/n)`,
+        defaultValue: null
+    })) {
+        currentOption = await setupOptionValueFromPrompt(currentOption, "path", "Dropbox target directory");
+    }
+    if (await yesno({
+        question: `Would you like to write drobadi config file in custom location (instead of default: ${DEFAULT_CONFIG_FILE_FRIENDLY}) ? (y/n)`,
+        defaultValue: null
+    })) {
+        targetConfigFile = await setupTargetConfigFile(DEFAULT_CONFIG_FILE_FRIENDLY);
+    }
+    fs.writeFileSync(targetConfigFile, JSON.stringify(currentOption, null, 2));
+    // DEBUG // console.log(currentOption);
+    console.log(`${targetConfigFile} OK`);
+}
+
+// TODO : test this

--- a/lib/DOptions.js
+++ b/lib/DOptions.js
@@ -1,23 +1,14 @@
 import fs from 'fs';
 import os from 'os';
-import yesno from 'yesno';
-import inquirer from 'inquirer';
 import {isSet} from './utils.js';
+import {dOptionLocalConfigFileSetup} from "./DOptionLocalConfigFile.js";
 
 const assumeEnvPrecedence = (envValue, defaultValue) => isSet(envValue) ? envValue : defaultValue;
 
 const HOMEDIR = os.homedir();
-const DEFAULT_CONFIG_FILE = `${HOMEDIR}/.drobadi`;
+export const DEFAULT_CONFIG_FILE = `${HOMEDIR}/.drobadi`;
+export const DEFAULT_CONFIG_FILE_FRIENDLY = '~/.drobadi';
 const CONFIG_FILE = assumeEnvPrecedence(process.env.DBD_CONFIG_FILE, DEFAULT_CONFIG_FILE);
-const CONFIG_FILE_FRIENDLY = '~/.drobadi';
-
-const tokenSetupHelp = () => console.log("please follow the instructions:\n\n" +
-    " 1) Open the following URL in your Browser, and log in using your account: https://www.dropbox.com/developers/apps (keep free default option with 2GB)\n" +
-    " 2) Go to developer center : https://www.dropbox.com/developers/apps/\n and Click on `Create App`, then select `Scoped access`, a type of access (ex. folder) and name your app to create it.\n" +
-    " 3) In the configuration, choose the app `Permissions` : you must check `files.content.write` and `files.content.read` and submit.\n" +
-    " 4) In the configuration, choose the app `Settings` : click on the `Generate` button located under \n" +
-    " the `Generated access token` section.\n\n" +
-    " The generated value is your dropboxToken. Copy/paste the value here\n\n");
 
 let optionConfig = null;
 try {
@@ -31,9 +22,28 @@ export default class DOptions {
     constructor(options) {
         const opt = options || {};
         this.description = "this is options for node package 'drobadi'";
-        this.dropboxToken = assumeOptionPrecedence(opt, "dropboxToken", process.env.DBD_DROPBOX_TOKEN, null);// dropbox application access token value
+        // legacy // deprecated
+        this.dropboxToken = assumeOptionPrecedence(opt, "dropboxToken", process.env.DBD_DROPBOX_TOKEN, null);// deprecated // dropbox application access token value
+        this.dropboxTokenDisableWarning = assumeOptionPrecedence(opt, "dropboxTokenDisableWarning", process.env.DBD_DROPBOX_TOKEN_DISABLE_WARNING, "false");
+
+        // DEV // console.log("DOptions:", JSON.stringify(opt, null, 2));
+        // DEV // console.log("this.dropboxToken:", this.dropboxToken);
+        if (isSet(this.dropboxToken) && this.dropboxTokenDisableWarning === "false") {
+            console.warn(
+                "WARN : 'dropboxToken' (long-lived dropbox provided access token) option is deprecated since September 30th, 2021\n" +
+                " doc : https://dropbox.tech/developers/migrating-app-permissions-and-access-tokens#retiring-legacy-tokens\n" +
+                " please switch to : dropboxRefreshToken, dropboxApplicationKey, dropboxApplicationSecret\n" +
+                " cf. drobadi readme for HowTo get them. This options will be removed in future drobadi version.");
+        }
+        // new oauth2 relying on long-lived refresh_token
+        this.dropboxAppKey = assumeOptionPrecedence(opt, "dropboxAppKey", process.env.DBD_DROPBOX_APP_KEY, null);// dropbox application key
+        this.dropboxAppSecret = assumeOptionPrecedence(opt, "dropboxAppSecret", process.env.DBD_DROPBOX_APP_SECRET, null);// dropbox application secret
+        this.dropboxRefreshToken = assumeOptionPrecedence(opt, "dropboxRefreshToken", process.env.DBD_DROPBOX_REFRESH_TOKEN, null);// dropbox application refresh token value
+
         this.path = assumeOptionPrecedence(opt, "path", process.env.DBD_PATH, 'backup');// dropbox target backup directory
+        // TODO - https://github.com/boly38/drobadi/issues/39
         this.force = assumeOptionPrecedence(opt, "force", process.env.DBD_FORCE, false);// override target backup
+
     }
 
     getPath() {
@@ -45,7 +55,7 @@ export default class DOptions {
     }
 
     static async setup() {
-        await setupOptions();
+        await dOptionLocalConfigFileSetup();
     }
 
     static unlink() {
@@ -67,62 +77,4 @@ const assumeOptionPrecedence = (options, optionName, envValue, defaultValue) => 
         return optionConfig[optionName];
     }
     return defaultValue;
-}
-
-const setupOptions = async () => {
-    let targetConfigFile = CONFIG_FILE;
-    let currentOption = new DOptions();
-    if (!isSet(currentOption.dropboxToken)
-        || (await yesno({question: 'Would you like to set dropboxToken ? (y/n)', defaultValue: null}))) {
-        currentOption = await setupToken(currentOption);
-    }
-    if (await yesno({
-        question: `Would you like to set dropbox directory(${currentOption.path}) ? (y/n)`,
-        defaultValue: null
-    })) {
-        currentOption = await setupDropboxDirectory(currentOption);
-    }
-    if (await yesno({
-        question: `Would you like to change drobadi config file (${CONFIG_FILE_FRIENDLY}) ? (y/n)`,
-        defaultValue: null
-    })) {
-        targetConfigFile = await setupTargetConfigFile(CONFIG_FILE_FRIENDLY);
-    }
-    fs.writeFileSync(targetConfigFile, JSON.stringify(currentOption, null, 2));
-    // DEBUG // console.log(currentOption);
-    console.log(`${targetConfigFile} OK`);
-}
-
-const setupToken = (option) => {
-    tokenSetupHelp();
-    return new Promise((resolve, reject) => {
-        const questions = [{type: 'input', name: 'dropboxToken', message: 'Dropbox generated token'}];
-        inquirer.prompt(questions).then((answers) => {
-            option.dropboxToken = answers.dropboxToken;
-            resolve(option);
-        });
-    });
-}
-
-const setupDropboxDirectory = (option) => {
-    return new Promise((resolve, reject) => {
-        const questions = [{type: 'input', name: 'path', message: 'Dropbox target directory'}];
-        inquirer.prompt(questions).then((answers) => {
-            option.path = answers.path;
-            resolve(option);
-        });
-    });
-}
-
-const setupTargetConfigFile = (defaultConfigFile) => {
-    return new Promise((resolve, reject) => {
-        const questions = [{
-            type: 'input',
-            name: 'configLocation',
-            message: `Dropbox target config file (default is ${defaultConfigFile})`
-        }];
-        inquirer.prompt(questions).then(answers => {
-            resolve(answers.configLocation)
-        });
-    });
 }

--- a/lib/DropboxBackupDirectory.js
+++ b/lib/DropboxBackupDirectory.js
@@ -6,7 +6,7 @@ import DOptions from './DOptions.js'
 import DDropbox from './DDropbox.js'
 import DArchiver from './DArchiver.js'
 
-const MUST_LOG_INFO = false;
+const MUST_LOG_INFO = process.env.DROBADI_BACKUP_VERBOSE === "true" || false;
 const TEMP_LOCAL_FILE = '__drobadi_tmp_archive.zip';
 
 const assumeOptions = (opt) => (opt === null || opt === undefined || !(opt instanceof DOptions)) ? new DOptions(opt) : opt;
@@ -18,8 +18,12 @@ export default class DropboxBackupDirectory {
     }
 
     list(opt) {
-        const options = assumeOptions(opt);
-        return this.dbx.listFromDropbox(options);
+        return new Promise((resolve, reject) => {
+            const options = assumeOptions(opt);
+            this.dbx.listFromDropbox(options)
+                .then(result => resolve(result))
+                .catch(err => reject(err));
+        });
     }
 
     backup(options, itemToBackup, backupZipDestinationName) {
@@ -33,21 +37,21 @@ export default class DropboxBackupDirectory {
             fs.existsSync(outArchFile) && fs.unlinkSync(outArchFile);
             MUST_LOG_INFO && console.log(`zip ${outArchFile} - ${itemToBackup}`);
             dbd.arch.zip(outArchFile, itemToBackup)
-                .catch(reject)
                 .then(zipResult => {
                     MUST_LOG_INFO && console.log(`uploadOnDropbox as ${backupZipDestinationName}`);
                     dbd.dbx.uploadOnDropbox(solvedOptions, zipResult, backupZipDestinationName)
-                        .catch(uploadError => {
-                            fs.unlinkSync(outArchFile);// remove temp zip file
-                            reject(uploadError);
-                        })
                         .then(uploadResult => {
                             // MUST_LOG_INFO && console.log(`uploadResult - ${JSON.stringify(uploadResult)}`);
                             MUST_LOG_INFO && console.log(`zip ${itemToBackup} - upload as ${uploadResult.dropboxFile}`);
                             fs.unlinkSync(outArchFile);// remove temp zip file
                             resolve({target: itemToBackup, zipResult, uploadResult});
                         })
+                        .catch(uploadError => {
+                            fs.unlinkSync(outArchFile);// remove temp zip file
+                            reject(uploadError);
+                        })
                 })
+                .catch(reject)
         });
     }
 
@@ -60,11 +64,11 @@ export default class DropboxBackupDirectory {
         return new Promise((resolve, reject) => {
             const toGetFile = isSet(localFile) ? localFile : path.basename(dbxBackupFile);
             dbd.dbx.downloadFromDropbox(options, dbxBackupFile, toGetFile)
-                .catch(reject)
                 .then(downloadResult => {
                     MUST_LOG_INFO && console.log(`zip ${dbxBackupFile} - downloaded as ${downloadResult.localFile}`);
                     resolve({downloadResult});
                 })
+                .catch(reject)
         });
     }
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,3 +6,9 @@ export const logWarn    = msg => console.warn(`WARN  ${msg}`);
 export const logError   = msg => console.error(` ERR  ${msg}`);
 export const logSuccess = msg => console.info(`  OK  ${msg}`);
 export const mkdirSync = directory => fs.mkdirSync(directory, {recursive: true});
+
+export const unlinkIfExists = localFilePath =>  {
+    if (fs.existsSync(localFilePath)) {
+        fs.unlinkSync(localFilePath);
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,9 @@
       "dependencies": {
         "archiver": "^5.3.1",
         "dateformat": "^4.5.1",
+        "dotenv": "^16.4.5",
         "dropbox": "^10.34.0",
+        "dropbox-refresh-token": "^0.0.2",
         "inquirer": "^8.2.2",
         "yesno": "^0.3.1"
       },
@@ -709,6 +711,17 @@
         "node": ">=0.3.1"
       }
     },
+    "node_modules/dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/dropbox": {
       "version": "10.34.0",
       "resolved": "https://registry.npmjs.org/dropbox/-/dropbox-10.34.0.tgz",
@@ -722,6 +735,11 @@
       "peerDependencies": {
         "@types/node-fetch": "^2.5.7"
       }
+    },
+    "node_modules/dropbox-refresh-token": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/dropbox-refresh-token/-/dropbox-refresh-token-0.0.2.tgz",
+      "integrity": "sha512-JBtihufN/3H7pMi/aYTvQAyhZ0L0ZFvUL0AXGF5BslUB/683ktQcZTlF6I7pG7dwKuHJqr6uYu26+OrQt53U5Q=="
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -2525,6 +2543,11 @@
       "version": "5.0.0",
       "dev": true
     },
+    "dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg=="
+    },
     "dropbox": {
       "version": "10.34.0",
       "resolved": "https://registry.npmjs.org/dropbox/-/dropbox-10.34.0.tgz",
@@ -2532,6 +2555,11 @@
       "requires": {
         "node-fetch": "^2.6.1"
       }
+    },
+    "dropbox-refresh-token": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/dropbox-refresh-token/-/dropbox-refresh-token-0.0.2.tgz",
+      "integrity": "sha512-JBtihufN/3H7pMi/aYTvQAyhZ0L0ZFvUL0AXGF5BslUB/683ktQcZTlF6I7pG7dwKuHJqr6uYu26+OrQt53U5Q=="
     },
     "emoji-regex": {
       "version": "8.0.0"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,9 @@
   "dependencies": {
     "archiver": "^5.3.1",
     "dateformat": "^4.5.1",
+    "dotenv": "^16.4.5",
     "dropbox": "^10.34.0",
+    "dropbox-refresh-token": "^0.0.2",
     "inquirer": "^8.2.2",
     "yesno": "^0.3.1"
   },

--- a/tests/drobadi.test.js
+++ b/tests/drobadi.test.js
@@ -1,26 +1,37 @@
 import fs from "fs";
-import { isSet, logInfo, logWarn, logSuccess, mkdirSync } from '../lib/utils.js';
-import { file, expect } from './testLib.js';
-import { _expectNoError, rmDirSync } from './testUtils.js';
+import {isSet, logInfo, logWarn, logSuccess, mkdirSync} from '../lib/utils.js';
+import {file, expect} from './testLib.js';
+import {_expectNoError, rmDirSync} from './testUtils.js';
 import {Drobadi, DOptions} from "../lib/drobadi.js";
 
-const testDbToken = process.env.DROBADI_TEST_DROPBOX_TOKEN || null;
+const {
+    DROBADI_TEST_DROPBOX_TOKEN,
+    DROBADI_TEST_APP_KEY,
+    DROBADI_TEST_APP_SECRET,
+    DROBADI_TEST_REFRESH_TOKEN
+} = process.env;
 const testBackupDirectory = "tmp/test-backup";
 const testRestoreDirectory = "tmp/test-restore";
 const testDropboxZipDestinationFilename = "drobadi-archive123.zip";// warn this file is removed by pre-condition
 const testDropboxTargetDirectory = "drobadi-test";
-const expectedDropboxTargetFullName = `/${testDropboxTargetDirectory}/${testDropboxZipDestinationFilename}`
 const expectedRestoredFile = `./${testDropboxZipDestinationFilename}`;
-const testDOptions = new DOptions({
-    "dropboxToken": testDbToken,
+
+let initialOptions = {
+    "dropboxAppKey": DROBADI_TEST_APP_KEY,
+    "dropboxAppSecret": DROBADI_TEST_APP_SECRET,
+    "dropboxRefreshToken": DROBADI_TEST_REFRESH_TOKEN,
     "path": testDropboxTargetDirectory,
     "force": true
-});
+};
+if (isSet(DROBADI_TEST_DROPBOX_TOKEN)) {
+    initialOptions["dropboxToken"] = DROBADI_TEST_DROPBOX_TOKEN; // legacy and deprecated
+}
+const testDOptions = new DOptions(initialOptions);
 
 let drobadi = new Drobadi();
 let lastArchiveSize;
 
-const VERBOSE = process.env.DROBADI_TEST_VERBOSE || false;
+const VERBOSE = process.env.DROBADI_TEST_VERBOSE === "true" || false;
 
 const cleanupConditions = () => {
     VERBOSE && logInfo(`cleanup test directories: ${testBackupDirectory},${testRestoreDirectory}`);
@@ -30,9 +41,11 @@ const cleanupConditions = () => {
 };
 
 const verifyDropboxTestTokenIsSet = () => {
-    if (!isSet(testDbToken)) {
-        logWarn("A dropbox token must be set in order to play tests");
-        expect(testDbToken, 'env.DROBADI_TEST_DROPBOX_TOKEN is NOT set').to.exist;
+    if (!isSet(DROBADI_TEST_APP_KEY) || !isSet(DROBADI_TEST_APP_SECRET) || !isSet(DROBADI_TEST_REFRESH_TOKEN)) {
+        logWarn("A dropbox app key,secret,refresh token must be set in order to play tests");
+        expect(DROBADI_TEST_APP_KEY, 'env.DROBADI_TEST_APP_KEY is NOT set').to.exist;
+        expect(DROBADI_TEST_APP_SECRET, 'env.DROBADI_TEST_APP_SECRET is NOT set').to.exist;
+        expect(DROBADI_TEST_REFRESH_TOKEN, 'env.DROBADI_TEST_REFRESH_TOKEN is NOT set').to.exist;
     }
 }
 
@@ -53,44 +66,42 @@ describe("Drobadi", () => {
         givenSampleFiles(testBackupDirectory);
 
         drobadi.backup(testDOptions, testBackupDirectory, testDropboxZipDestinationFilename)
-            .catch(_expectNoError)
             .then(backupResult => {
                 const uploadResult = backupResult.uploadResult;
                 VERBOSE && logSuccess(uploadResult.message);
                 backupResult.target.should.be.eql(testBackupDirectory);
-                expect(uploadResult.dropboxFile).to.be.eql(expectedDropboxTargetFullName);
+                expect(uploadResult.dropboxFile).to.be.eql(`/${testDropboxTargetDirectory}/${testDropboxZipDestinationFilename}`);
                 expect(uploadResult.dropboxFileSize).to.be.within(300, 500);
                 lastArchiveSize = uploadResult.dropboxFileSize;
                 done();
-            });
+            })
+            .catch(_expectNoError);
 
     });
 
     it("should list backup", (done) => {
         drobadi.list(testDOptions)
-            .catch(_expectNoError)
             .then(listResult => {
                 VERBOSE && logSuccess(listResult);
-                expect(listResult).to.contain(expectedDropboxTargetFullName);
+                expect(listResult).to.contain(testDropboxZipDestinationFilename);
                 done();
-            })
+            }).catch(_expectNoError);
     });
 
     it("should restore backup in current directory", (done) => {
         drobadi.download(testDOptions, testDropboxZipDestinationFilename)
-            .catch(_expectNoError)
             .then(restoreResult => {
                 const downloadResult = restoreResult.downloadResult;
                 VERBOSE && logSuccess(downloadResult.message);
 
-                expect(downloadResult.dropboxFile).to.be.eql(expectedDropboxTargetFullName);
+                expect(downloadResult.dropboxFile).to.be.eql(`/${testDropboxTargetDirectory}/${testDropboxZipDestinationFilename}`);
                 expect(downloadResult.localFile).to.be.eql(testDropboxZipDestinationFilename);
                 expect(downloadResult.dropboxFileSize).to.be.eql(lastArchiveSize);
 
                 expect(file(expectedRestoredFile)).to.exist;
                 expect(fs.statSync(expectedRestoredFile).size).to.be.eql(lastArchiveSize);
                 done();
-            });
+            }).catch(_expectNoError);
     });
 
     it("should restore backup in specified file", (done) => {
@@ -99,19 +110,19 @@ describe("Drobadi", () => {
         const destination = `${testRestoreDirectory}/restored.zip`;
 
         drobadi.download(testDOptions, testDropboxZipDestinationFilename, destination)
-            .catch(_expectNoError)
             .then(restoreResult => {
                 const downloadResult = restoreResult.downloadResult;
                 VERBOSE && logSuccess(downloadResult.message);
 
-                expect(downloadResult.dropboxFile).to.be.eql(expectedDropboxTargetFullName);
+                expect(downloadResult.dropboxFile).to.be.eql(`/${testDropboxTargetDirectory}/${testDropboxZipDestinationFilename}`);
                 expect(downloadResult.localFile).to.be.eql(destination);
                 expect(downloadResult.dropboxFileSize).to.be.eql(lastArchiveSize);
 
                 expect(file(destination)).to.exist;
                 expect(fs.statSync(destination).size).to.be.eql(lastArchiveSize);
                 done();
-            });
+            })
+            .catch(_expectNoError);
     });
 
 })


### PR DESCRIPTION
Fix #38 rely on dropboxRefreshToken +refacto
environment
- add dropbox appKey,appSecret,refreshToken : current way to have long-lived offline token
- dropboxToken is DEPRECATED and may be removed in future version

core
- review of promise for negative cases
- dropbox api response payload has changed, fix some negative handler
- seems side effect on upload+"force" option too, cf ticket #39

"list" action
- dont repeat dropbox target directory as prefix as this is not needed for "download" action and introduce some confusion